### PR TITLE
Fix 0x97A3646645727F42

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -33734,12 +33734,12 @@
 			"build": "1207"
 		},
 		"0x97A3646645727F42": {
-			"name": "_INVENTORY_CREATE_ITEM_COLLECTION",
+			"name": "_INVENTORY_CREATE_ITEM_COLLECTION_2",
 			"comment": "Returns collectionId",
 			"params": [
 				{
-					"type": "Any*",
-					"name": "p0"
+					"type": "int*",
+					"name": "collectionSize"
 				}
 			],
 			"return_type": "int",


### PR DESCRIPTION
fixed naming of 0x97A3646645727F42 which was named after a native with the same name.